### PR TITLE
[WALLET-64] Accept resolveAuthorizationUrl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,11 +52,16 @@ Open shadow root holding one `<button>`, the seal `<svg>`, and a `<span>` label 
 - A single module-scope `CSSStyleSheet` built from `styles.ts` is adopted into every shadow root via `adoptedStyleSheets`.
 - `observedAttributes = ["size"]` — only `size` drives structural state (label visibility + `aria-label`). `theme` is pure CSS. `nonce`, `state`, `login-hint`, `transaction-data` are read at click time, not observed.
 - No `connectedCallback`. `attributeChangedCallback` fires on parser upgrade, `setAttribute`, and framework attribute updates — covering React/Vue/Svelte.
-- Click handler: resolve `nonce` (required, throws if missing), plus optional `state` / `login-hint` / transaction data; call `getAuthorizationRequestURL(...)`; set `window.location.href`. The button is `disabled` while the request is pending.
+- The `click` listener is on the **host** (`this`), not the inner `<button>`. A real button click bubbles up to the host (click is `composed`), and a programmatic `host.click()` fires on the host directly — so a consumer's form can trigger the flow with `el.querySelector("proof-verify-id").click()`, no shadow-root piercing. (Listening on the inner button would miss `host.click()`, since events don't propagate down into the shadow tree.)
+- `#navigate()` resolves the redirect URL, then sets `window.location.href` (a nullish URL aborts). It is `disabled` / busy while pending. The URL comes from either the `resolveAuthorizationUrl` property (if set) or `#buildAuthorizationUrl()` — see below.
+
+### resolveAuthorizationUrl — custom URL resolver
+
+`resolveAuthorizationUrl?: () => string | null | undefined | Promise<...>` is a property-only escape hatch. When set, `#navigate()` awaits it and redirects to its result instead of calling `#buildAuthorizationUrl()`; the `nonce` / `state` / `login-hint` / `transaction-data` inputs are ignored and `nonce` is not required. A nullish return aborts the redirect (the button re-enables); a throw propagates with the button restored. Use it for flows where the URL is produced elsewhere (e.g. a pushed authorization request made by the consumer). JS/JSX path only (it's a function); in TSX it's set as a property — works on React 19, use a ref on older React.
 
 ### nonce and transaction data — property vs attribute
 
-Both are read property-first, attribute-fallback in `#onClick`:
+Both are read property-first, attribute-fallback in `#buildAuthorizationUrl()`:
 
 - **`nonce`** — read as `this.nonce || this.getAttribute("nonce")`. `nonce` is a built-in IDL property, so frameworks assign it as a property (never calling `setAttribute`); property-first is required, or `getAttribute` returns null.
 - **`transaction_data`** (`AuthorizationRequestParams.transaction_data` accepts `TransactionData | string`):

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Read our [documentation](https://dev.proof.com/docs/digital-credentials-overview
 - [Installation](#installation)
 - [Getting Started](#getting-started)
   - [Transaction Templates](#transaction-templates)
+  - [Custom authorization URL](#custom-authorization-url)
 - [Styles](#styles)
 - [TypeScript](#typescript)
   - [React](#react)
@@ -76,6 +77,19 @@ const data = transactionData.paymentItemized({
   transactionData={data}
 />;
 ```
+
+### Custom authorization URL
+
+You can pass a `resolveAuthorizationUrl` property to create your own authorization request URL (e.g. a Pushed Authorization Request server-side).
+When set, the element ignores the `nonce` / `state` / `login-hint` / `transactionData` attributes.
+
+```javascript
+<proof-verify-id
+  resolveAuthorizationUrl={async () => await getAuthorizationRequestURL()}
+/>
+```
+
+Return `null` (or `undefined`) to cancel the redirect.
 
 ## Styles
 

--- a/src/proof_verify_id.ts
+++ b/src/proof_verify_id.ts
@@ -22,6 +22,12 @@ const Base: typeof HTMLElement =
 
 const LABEL = "Continue with Proof";
 
+export type AuthorizationUrlResolver = () =>
+  | string
+  | null
+  | undefined
+  | Promise<string | null | undefined>;
+
 export class ProofVerifyId extends Base {
   static readonly observedAttributes = ["size"] as const;
 
@@ -29,12 +35,20 @@ export class ProofVerifyId extends Base {
   readonly #label: HTMLSpanElement;
   #pending = false;
   #transactionData: TransactionData | undefined;
+  #resolveAuthorizationUrl: AuthorizationUrlResolver | undefined;
 
   get transactionData(): TransactionData | undefined {
     return this.#transactionData;
   }
   set transactionData(value: TransactionData | undefined) {
     this.#transactionData = value;
+  }
+
+  get resolveAuthorizationUrl(): AuthorizationUrlResolver | undefined {
+    return this.#resolveAuthorizationUrl;
+  }
+  set resolveAuthorizationUrl(value: AuthorizationUrlResolver | undefined) {
+    this.#resolveAuthorizationUrl = value;
   }
 
   constructor() {
@@ -63,8 +77,11 @@ export class ProofVerifyId extends Base {
 
     this.#button.append(content);
 
-    this.#button.addEventListener("click", () => {
-      void this.#onClick();
+    // Listen on the host, not the inner button, so a programmatic
+    // `host.click()` (e.g. a form's submit handler) triggers the flow.
+    // A real click on the inner button bubbles up to the host too.
+    this.addEventListener("click", () => {
+      void this.#navigate();
     });
 
     shadow.appendChild(this.#button);
@@ -84,32 +101,42 @@ export class ProofVerifyId extends Base {
     }
   }
 
-  async #onClick() {
+  async #navigate() {
     if (this.#pending) return;
+
+    this.#pending = true;
+    this.#setBusy(true);
+    try {
+      const url = this.#resolveAuthorizationUrl
+        ? await this.#resolveAuthorizationUrl()
+        : await this.#buildAuthorizationUrl();
+
+      // A nullish result aborts the redirect (e.g. the resolver cancelled).
+      if (url) window.location.href = url;
+    } finally {
+      this.#pending = false;
+      this.#setBusy(false);
+    }
+  }
+
+  async #buildAuthorizationUrl(): Promise<string> {
     const nonce = this.nonce || this.getAttribute("nonce");
     if (!nonce) {
       throw new Error("<proof-verify-id>: 'nonce' is required");
     }
 
-    this.#pending = true;
-    this.#setBusy(true);
-    try {
-      const state = this.getAttribute("state");
-      const login_hint = this.getAttribute("login-hint");
-      const transaction_data =
-        this.#transactionData ?? this.getAttribute("transaction-data");
+    const state = this.getAttribute("state");
+    const login_hint = this.getAttribute("login-hint");
+    const transaction_data =
+      this.#transactionData ?? this.getAttribute("transaction-data");
 
-      window.location.href = await getAuthorizationRequestURL({
-        nonce,
-        scope: "urn:proof:params:scope:verifiable-credentials:basic",
-        ...(state !== null && { state }),
-        ...(login_hint !== null && { login_hint }),
-        ...(transaction_data !== null && { transaction_data }),
-      });
-    } finally {
-      this.#pending = false;
-      this.#setBusy(false);
-    }
+    return getAuthorizationRequestURL({
+      nonce,
+      scope: "urn:proof:params:scope:verifiable-credentials:basic",
+      ...(state !== null && { state }),
+      ...(login_hint !== null && { loginHint: login_hint }),
+      ...(transaction_data !== null && { transactionData: transaction_data }),
+    });
   }
 
   #setBusy(busy: boolean) {

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,15 +1,21 @@
 import type { HTMLAttributes } from "react";
-import type { ProofVerifyId } from "./proof_verify_id.ts";
+import type {
+  AuthorizationUrlResolver,
+  ProofVerifyId,
+} from "./proof_verify_id.ts";
 import type { TransactionData } from "@proof.com/proof-vc-common";
 
 export interface ProofVerifyIdJSXAttributes extends HTMLAttributes<ProofVerifyId> {
-  nonce: string;
+  nonce?: string;
   state?: string;
   theme?: "dark" | "gray" | "outline" | "primary";
   size?: "icon" | "small" | "medium" | "large";
   "login-hint"?: string;
   "transaction-data"?: string;
   transactionData?: TransactionData;
+  // Set as a property (React 19 assigns matching props on custom elements);
+  // on React < 19 use a ref instead, as function props are stringified.
+  resolveAuthorizationUrl?: AuthorizationUrlResolver;
 }
 
 declare module "react" {


### PR DESCRIPTION
## Summary

Adds a `resolveAuthorizationUrl` property to `<proof-verify-id>` so consumers can supply their own authorization request URL — for example, a pushed authorization request (PAR) the app makes itself. When set, the element awaits it on click and redirects to its result, ignoring `nonce`/`state`/`login-hint`/`transaction-data`; a nullish return aborts the redirect. This replaces the previous consumer-side capture-phase click interception with a supported public API.

Two supporting changes:

- **Click listener moved to the host.** It now lives on the host element instead of the inner shadow `<button>`, so a programmatic `el.click()` (e.g. from a form's `onSubmit`) triggers the flow without piercing the shadow root. Real button clicks still bubble up to the host.
- **Fixed param key casing.** `getAuthorizationRequestURL` expects `loginHint`/`transactionData` (camelCase); the previous snake_case keys were silently dropped through the object spread (TS doesn't excess-property-check spreads).

## API

```jsx
<proof-verify-id
  resolveAuthorizationUrl={async () => {
    const { request_uri } = await startPushedAuthorizationRequest();
    return buildAuthorizationUrl(request_uri);
  }}
/>
```

Set as a property; on React 19 it's assigned as a prop, on older React use a ref. Returning `null`/`undefined` cancels the redirect.

## Testing

- `yarn check-all` passes (format, lint, typecheck, publint).
- No unit-test suite in this repo; behavior verified manually via the linked package in a consuming app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)