### PR TITLE
Bump @proof.com/proof-vc-common to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@proof.com/proof-vc-common": "^0.1.3"
+    "@proof.com/proof-vc-common": "^0.2.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,10 +99,10 @@
   resolved "https://registry.yarnpkg.com/@owf/identity-common/-/identity-common-0.2.0.tgz#8f949ee972a1a22c5eec6a7b1499d9e1f783b339"
   integrity sha512-liOcJpoUxKkvAOko93VvrpC0w9ft+/D6lalrLoXrgrdd3/q3kGx2IeQ8fcrspw+F3IURfcvdDEH/RwEMx0DKMg==
 
-"@proof.com/proof-vc-common@^0.1.3":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@proof.com/proof-vc-common/-/proof-vc-common-0.1.4.tgz#25cb35827f2457ce040e531f774df072b0107062"
-  integrity sha512-ZLyxhEo6EpNXQvxiRfalt6a+L/o3T6xUEQWhSmeGXuO8V6yvXiStPGmmxMBMk8w+cSnOuNCcNnKbXvGgLRgD+Q==
+"@proof.com/proof-vc-common@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@proof.com/proof-vc-common/-/proof-vc-common-0.2.0.tgz#308bba2a5df3051490e50b0f857280dc1ca9b433"
+  integrity sha512-RbmdV8uyQdnqvvffop9F8+mhdurMfpZ7Ob/GP43psh54VqpUAVt4zy7KxgOLRwMNdmX6ba459VvN9tRhNHYadg==
   dependencies:
     "@owf/crypto" "^0.2.0"
     "@owf/identity-common" "^0.2.0"


### PR DESCRIPTION
## Summary

Raise the `@proof.com/proof-vc-common` dependency range from `^0.1.3` to `^0.2.0` and update `yarn.lock` (resolves to `0.2.0`, published on npm).

`^0.1.3` cannot resolve `0.2.0` (caret below 1.0 is patch-only), so the range needs an explicit bump.

## Testing

- `yarn check-all` passes (format, lint, typecheck, publint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)