### PR TITLE
Release 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proof.com/proof-vc-web",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Web Components for Proof Digital Credentials.",
   "keywords": [
     "VC",


### PR DESCRIPTION
## Release 0.2.0

Bumps `package.json` to `0.2.0`.

### Changes since 0.1.4
- Add `resolveAuthorizationUrl` property; move click listener to the host so `el.click()` triggers the flow; fix camelCase param keys (#15)
- Bump `@proof.com/proof-vc-common` to `0.2.0` (#16)
- Dependency group bumps (#13, #14)

After merge, a GitHub Release `v0.2.0` against the merged commit triggers the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)