### PR TITLE
Fix site init params for proof-vc-common 0.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Browser-only ESM TypeScript package `@proof.com/proof-vc-web`. Ships one Web Com
    - `customElements.define(...)` → guarded by `typeof customElements !== "undefined"`.
 3. **Never reference `src/react.ts` from `src/index.ts`.** It's the types-only sub-path entry (`@proof.com/proof-vc-web/react`); importing it from the main entry forces every non-React consumer to install `@types/react`.
 4. **Prompt before publishing.** Never bump the version, push tags, create a Release, or trigger the publish workflow without explicit confirmation — publishes are permanent.
-5. **Run `yarn check-all` before any commit or push.** It's this repo's "tests + lint": format, lint, typecheck, publint.
+5. **Run `yarn check-all` before any commit or push.** It's this repo's "tests + lint": format, lint, typecheck, publint. `check-all` does **not** cover `site/` (root `tsconfig.json` excludes it). Since `site/` imports parent `src/` and pulls `proof-vc-common`, changes to `src/`, dependencies, or `site/` can break the site's CI even when `check-all` passes — so also run the site's checks before commit: `cd site && yarn format:check && yarn lint:check && yarn typecheck && yarn build`.
 6. **Keep `yarn publint` on `--pack npm`.** `--pack auto` picks yarn-1 mode and reports false-positive "file not published" errors.
 7. **Don't lower `engines.node` below `>=22.0.0`.** Matches proof-vc-common.
 8. **Never silence lint with `eslint-disable`.** Fix the underlying issue, not the warning. The only sanctioned exception is a reviewed config override (e.g. the per-file `no-namespace` rule for `src/react.ts` in `eslint.config.js`) — not inline disable comments.

--- a/site/src/index.ts
+++ b/site/src/index.ts
@@ -2,8 +2,8 @@ import { init, transactionData, ProofVerifyId } from "../../src/index.ts";
 
 init({
   environment: "next",
-  client_id: "caxdw5a7d",
-  callback_uri: "http://localhost:4000",
+  clientId: "caxdw5a7d",
+  callbackUri: "http://localhost:4000",
 });
 
 const txDemo = document.querySelector<ProofVerifyId>(


### PR DESCRIPTION
## Summary

`proof-vc-common@0.2.0` renamed the `init` params to camelCase (`client_id` → `clientId`, `callback_uri` → `callbackUri`). `site/src/index.ts` still used the old names, breaking the `site` CI job after #16 landed on `main`.

- Update `site/src/index.ts` to `clientId` / `callbackUri`.
- Document in `CLAUDE.md` that `yarn check-all` does not cover `site/`, so the site's checks must also be run before commit.

## Why CI caught what the local gate didn't

`yarn check-all` runs root `tsc`, and the root `tsconfig.json` excludes `site/`. The site is only typechecked by the separate `site` CI job. The CLAUDE.md update closes that gap.

## Testing

- `yarn check-all` passes.
- `cd site && yarn format:check && yarn lint:check && yarn typecheck && yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)