### PR TITLE
Release 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proof.com/proof-vc-web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Web Components for Proof Digital Credentials.",
   "keywords": [
     "VC",


### PR DESCRIPTION
Release 0.3.0.

Bumps the package version to 0.3.0 following the update to `@proof.com/proof-vc-common@0.3.0` (#29): the one-shot `buildAuthorizationUrl` API, config moved to element attributes (`environment` / `client-id` / `callback-uri` / `response-mode`), and removal of `init` / `transactionData`.

Version-only change; merge to trigger the Release + npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)