### PR TITLE
[WALLET-124] Lower Node engine to >= 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,34 +34,63 @@ jobs:
       - run: yarn install
       - run: yarn lint:check
 
-  typecheck:
+  typecheck-matrix:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v7
       - run: corepack enable
       - uses: actions/setup-node@v6
         with:
-          node-version-file: .node-version
+          node-version: ${{ matrix.node-version }}
           cache: yarn
       - run: yarn install
       - run: yarn typecheck
 
-  build:
+  typecheck:
+    needs: typecheck-matrix
+    if: always()
     runs-on: ubuntu-latest
+    steps:
+      - if: needs.typecheck-matrix.result != 'success'
+        run: exit 1
+
+  build-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v7
       - run: corepack enable
       - uses: actions/setup-node@v6
         with:
-          node-version-file: .node-version
+          node-version: ${{ matrix.node-version }}
           cache: yarn
       - run: yarn install
       - run: yarn build
-      - uses: actions/upload-artifact@v7
+      # publint resolves the package `exports` against the packed tarball, which
+      # references ./dist/*. Upload once, from the Node 24 (.node-version) leg,
+      # for the publint job to reuse.
+      - if: matrix.node-version == 24
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist
           retention-days: 1
+
+  # Stable required-check name for the branch ruleset (see typecheck gate).
+  build:
+    needs: build-matrix
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.build-matrix.result != 'success'
+        run: exit 1
 
   publint:
     needs: build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Browser-only ESM TypeScript package `@proof.com/proof-vc-web`. Ships one Web Com
 4. **Prompt before publishing.** Never bump the version, push tags, create a Release, or trigger the publish workflow without explicit confirmation — publishes are permanent.
 5. **Run `yarn check-all` before any commit or push.** It's this repo's "tests + lint": format, lint, typecheck, publint. `check-all` does **not** cover `site/` (root `tsconfig.json` excludes it). Since `site/` imports parent `src/` and pulls `proof-vc-common`, changes to `src/`, dependencies, or `site/` can break the site's CI even when `check-all` passes — so also run the site's checks before commit: `cd site && yarn format:check && yarn lint:check && yarn typecheck && yarn build`.
 6. **Keep `yarn publint` on `--pack npm`.** `--pack auto` picks yarn-1 mode and reports false-positive "file not published" errors.
-7. **Don't lower `engines.node` below `>=24.0.0`.** Matches the repo's pinned Node toolchain (`.node-version`).
+7. **Keep `engines.node` at `>=22.0.0`; keep the CI `typecheck-matrix` / `build-matrix` legs covering it.** Node 22 is the oldest maintained LTS (20 is EOL; `@sd-jwt/*` needs 20+). No test suite and no `@types/node`, so nothing runtime-guards the floor — the matrices run `yarn typecheck` / `yarn build` on Node 22 and 24 instead. Dev is on Node 24 (`.node-version`). Keep the low leg equal to the floor; raise both together.
 8. **Never silence lint with `eslint-disable`.** Fix the underlying issue, not the warning. The only sanctioned exception is a reviewed config override (e.g. the per-file `no-namespace` rule for `src/react.ts` in `eslint.config.mjs`) — not inline disable comments.
 
 ## Essential Commands
@@ -127,7 +127,8 @@ Replace the `SEAL_SVG` string in `proof_verify_id.ts` (assigned to `button.inner
 
 `.github/workflows/ci.yml`, on push and PR to `main`. One job per check, run in parallel: `format`, `lint`, `typecheck`, `build`, `publint`, `site`.
 
-- `build` uploads `dist/` as an artifact; `publint` `needs: build` and downloads it (publint resolves `exports` against the packed tarball, so it needs the build output).
+- `typecheck` and `build` each run as a Node 22 + 24 `*-matrix`, fronted by a same-named aggregate gate (`needs: *-matrix`, `if: always()`) so the ruleset needs only the stable `typecheck` / `build` check names, not the matrix legs. `format`, `lint`, `publint`, `site` stay single jobs on Node 24.
+- `build-matrix` uploads `dist/` from its Node 24 leg; `publint` `needs: build` and downloads it (publint resolves `exports` against the packed tarball).
 - `site` installs root deps then `site/` deps — `site/` imports parent `src/`, which pulls `proof-vc-common` from the root `node_modules` — then runs the site's `format:check`, `lint:check`, `typecheck`, `build`.
 - Workflow-level `permissions: contents: read`; the publish job adds `id-token: write` for OIDC.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- `node` >= 24.0.0 (CI and local dev use the version pinned in `.node-version`, currently 24.14.1)
+- `node` >= 22.0.0 (minimum supported, the `engines.node` floor). Develop on Node 24 (active LTS), pinned in `.node-version`.
 - `yarn` (Berry) — pinned by the committed release under `.yarn/releases/`, referenced by `yarnPath`. Any `yarn` on your PATH delegates to it, so Homebrew's yarn 1.x works fine. If you have no `yarn` at all, run `corepack enable` once to get one — it ships with Node, and the pinned release takes over from there.
 
 Installs are immutable: a plain `yarn install` never modifies `yarn.lock` and fails if it is out of sync with `package.json`. After adding or bumping a dependency, run `yarn install --no-immutable` and commit the updated `yarn.lock`.
@@ -31,6 +31,8 @@ To submit a pull request:
 - Start by forking the repo and branching off of `main`.
 - Include a clear title and description explaining what changed and why.
 - Keep changes focused, try to limit one issue or feature per PR.
+
+CI runs `typecheck` and `build` on a matrix of Node 22 (the `engines.node` floor) and Node 24 (active LTS, from `.node-version`). The other jobs (`format`, `lint`, `publint`, `site`) run on Node 24.
 
 ## Code of conduct
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "packageManager": "yarn@4.17.0",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Lower `engines.node` to `>=22.0.0` (oldest maintained LTS) and verify the floor with a Node 22 + 24 `typecheck`/`build` CI matrix; docs updated to match.